### PR TITLE
Mark Linien as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-  "publish-delay-hours": 1
+  "publish-delay-hours": 1,
+  "end-of-life": "This application is no longer maintained."
 }


### PR DESCRIPTION
This application relies on an outdated runtime that was marked as end-of-life (EOL) five years ago.

https://github.com/flathub/io.github.hermitdemschoenenleben.linien/issues/2